### PR TITLE
日報作成機能実装

### DIFF
--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -13,6 +13,11 @@ class CalendarController < ApplicationController
                        @today.beginning_of_month
                      end
     @calendar_days = build_calendar_days(@current_month)
+
+    # 現在表示している月の日報データを取得（日付をキーとしたハッシュ）
+    @reports = current_user.reports.
+                 where(date: @calendar_days.first..@calendar_days.last).
+                 index_by(&:date)
   end
 
   private

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,32 @@
+class ReportsController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @report = current_user.reports.build
+    @report.date = if params[:date].present?
+                     begin
+                       Date.parse(params[:date])
+                     rescue Date::Error
+                       Date.current
+                     end
+                   else
+                     Date.current
+                   end
+  end
+
+  def create
+    @report = current_user.reports.build(report_params)
+
+    if @report.save
+      redirect_to calendar_path, notice: t("flash.reports.create.notice")
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+    def report_params
+      params.require(:report).permit(:date, :body)
+    end
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,6 @@
+class Report < ApplicationRecord
+  belongs_to :user
+
+  validates :date, presence: true, uniqueness: { scope: :user_id, message: "の日報は既に作成されています" }
+  validates :body, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_many :reports, dependent: :destroy
+
   # カスタムパスワードバリデーション
   validate :password_complexity, if: :password_required?
 

--- a/app/views/calendar/index.html.erb
+++ b/app/views/calendar/index.html.erb
@@ -48,7 +48,7 @@
           <% report = @reports[date] %>
           <% has_report = report.present? %>
           
-          <%= link_to has_report ? report_path(report) : new_report_path(date: date.strftime('%Y-%m-%d')), 
+          <%= link_to new_report_path(date: date.strftime('%Y-%m-%d')), 
               class: "relative border-r border-b border-gray-200 h-24 group hover:bg-gray-50 transition-colors cursor-pointer block
                       #{'bg-blue-50' if is_today}" do %>
             

--- a/app/views/calendar/index.html.erb
+++ b/app/views/calendar/index.html.erb
@@ -45,9 +45,12 @@
           <% is_current_month = date.month == @current_month.month %>
           <% is_sunday = date.wday == 0 %>
           <% is_saturday = date.wday == 6 %>
+          <% report = @reports[date] %>
+          <% has_report = report.present? %>
           
-          <div class="relative border-r border-b border-gray-200 h-24 group hover:bg-gray-50 transition-colors cursor-pointer
-                      <%= 'bg-blue-50' if is_today %>">
+          <%= link_to has_report ? report_path(report) : new_report_path(date: date.strftime('%Y-%m-%d')), 
+              class: "relative border-r border-b border-gray-200 h-24 group hover:bg-gray-50 transition-colors cursor-pointer block
+                      #{'bg-blue-50' if is_today}" do %>
             
             <!-- 日付番号 -->
             <div class="p-2">
@@ -68,6 +71,7 @@
                 <%= date.day %>
               </span>
               
+              <!-- 今日のマーク -->
               <% if is_today %>
                 <div class="absolute top-1 right-1">
                   <div class="w-2 h-2 bg-blue-600 rounded-full"></div>
@@ -75,38 +79,48 @@
               <% end %>
             </div>
 
-            <% if false # TODO: 日報データがある場合 %>
+            <!-- 日報があるかどうかの表示 -->
+            <% if has_report %>
               <div class="absolute bottom-2 left-2">
                 <div class="w-2 h-2 bg-green-500 rounded-full"></div>
               </div>
             <% end %>
 
+            <!-- ホバー時の効果 -->
             <div class="absolute inset-0 bg-blue-100 opacity-0 group-hover:opacity-20 transition-opacity pointer-events-none"></div>
-          </div>
+          <% end %>
         <% end %>
       </div>
     </div>
 
+    <!-- 凡例 -->
     <div class="mt-6 flex flex-wrap items-center justify-center space-x-6 text-sm text-gray-600">
       <div class="flex items-center space-x-2">
         <div class="w-3 h-3 bg-blue-600 rounded-full"></div>
         <span>今日</span>
       </div>
+      <div class="flex items-center space-x-2">
+        <div class="w-3 h-3 bg-green-500 rounded-full"></div>
+        <span>日報あり</span>
+      </div>
     </div>
   </div>
 
+  <!-- 今日の日報を書くボタン（右下固定） -->
   <div class="fixed bottom-14 right-14 z-50">
-    <%= link_to "#", # TODO: 日報作成ページへのパスを設定
+    <%= link_to new_report_path(date: @today.strftime('%Y-%m-%d')), 
         class: "relative group bg-blue-600 hover:bg-blue-700 text-white p-4 rounded-full shadow-lg hover:shadow-xl transition-all duration-200 transform hover:scale-105 block" do %>
       <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" 
               d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"></path>
       </svg>
       
+      <!-- ツールチップ -->
       <div class="absolute bottom-full right-0 mb-3 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none">
         <div class="bg-gray-900 text-white text-sm px-3 py-2 rounded-lg whitespace-nowrap">
           今日の日報を書く
         </div>
+        <!-- 矢印 -->
         <div class="absolute top-full right-3 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-900"></div>
       </div>
     <% end %>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,0 +1,61 @@
+<div class="min-h-screen bg-gray-50 py-8">
+  <div class="max-w-6xl mx-auto px-4">
+    <!-- ヘッダー -->
+    <div class="mb-8">
+      <div class="flex items-center justify-between">
+        <div>
+          <h1 class="text-3xl font-bold text-gray-900">日報作成</h1>
+          <p class="text-gray-600 mt-1"><%= @report.date.strftime('%Y年%m月%d日') %>の日報</p>
+        </div>
+        
+        <%= link_to calendar_path, class: "text-gray-600 hover:text-gray-900 flex items-center space-x-1 transition-colors" do %>
+          <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
+          </svg>
+          <span>カレンダーに戻る</span>
+        <% end %>
+      </div>
+    </div>
+
+    <!-- エラーメッセージ -->
+    <% if @report.errors.any? %>
+      <div class="mb-6 bg-red-50 border border-red-200 rounded-md p-4">
+        <h3 class="text-red-800 font-medium mb-2">エラーがあります:</h3>
+        <ul class="text-red-700 text-sm space-y-1">
+          <% @report.errors.full_messages.each do |message| %>
+            <li><%= message %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <!-- フォーム -->
+    <%= form_with model: @report, local: true, class: "space-y-6" do |form| %>
+      <!-- 日付フィールド -->
+      <div>
+        <%= form.label :date, Report.human_attribute_name(:date), class: "block text-sm font-medium text-gray-700 mb-2" %>
+        <%= form.date_field :date, 
+            class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500" %>
+      </div>
+
+      <!-- マークダウンエディタ -->
+      <div>
+        <%= form.label :body, "#{Report.human_attribute_name(:body)}（Markdown形式）", class: "block text-sm font-medium text-gray-700 mb-2" %>
+        
+        <%= form.text_area :body, 
+            rows: 20,
+            placeholder: "今日の作業内容をマークダウンで記入してください...\n\n例:\n## 完了したタスク\n- [ ] タスク1\n- [x] 完了したタスク\n\n## 学習内容\n### 新しく学んだこと\n- Rails 7の新機能\n\n## 明日の予定\n1. 機能Aの実装\n2. テストの作成",
+            class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 font-mono text-sm" %>
+      </div>
+
+      <!-- 送信ボタン -->
+      <div class="flex items-center justify-between pt-6">
+        <%= link_to "キャンセル", calendar_path, 
+            class: "text-gray-600 hover:text-gray-900 px-4 py-2 border border-gray-300 rounded-md transition-colors" %>
+        
+        <%= form.submit t('helpers.submit.report.create'), 
+            class: "bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-md shadow transition-colors" %>
+      </div>
+    <% end %>
+  </div>
+</div> 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,7 +3,6 @@ ja:
     models:
       user: "ユーザー"
       report: "日報"
-    
     attributes:
       user:
         email: "メールアドレス"
@@ -11,14 +10,12 @@ ja:
         password_confirmation: "パスワード確認"
         current_password: "現在のパスワード"
         remember_me: "ログイン状態を保持する"
-      
       report:
         date: "日付"
         body: "内容"
         user: "ユーザー"
         created_at: "作成日時"
         updated_at: "更新日時"
-    
     errors:
       models:
         user:
@@ -31,7 +28,6 @@ ja:
               blank: "を入力してください"
               too_short: "は%{count}文字以上で入力してください"
               confirmation: "と確認が一致しません"
-        
         report:
           attributes:
             date:
@@ -39,7 +35,6 @@ ja:
               taken: "の日報は既に作成されています"
             body:
               blank: "を入力してください"
-  
   # フラッシュメッセージ
   flash:
     reports:
@@ -52,22 +47,12 @@ ja:
       destroy:
         notice: "日報を削除しました"
         alert: "日報の削除に失敗しました"
-  
   # 日付・時間の表示フォーマット
   date:
     formats:
       default: "%Y年%m月%d日"
       short: "%m/%d"
       long: "%Y年%m月%d日(%a)"
-  
-  time:
-    formats:
-      default: "%Y年%m月%d日 %H:%M"
-      short: "%m/%d %H:%M"
-      long: "%Y年%m月%d日(%a) %H時%M分%S秒"
-  
-  # 曜日
-  date:
     abbr_day_names:
       - 日
       - 月
@@ -84,7 +69,6 @@ ja:
       - 木曜日
       - 金曜日
       - 土曜日
-    
     abbr_month_names:
       - ~
       - 1月
@@ -113,7 +97,13 @@ ja:
       - 10月
       - 11月
       - 12月
-  
+
+  time:
+    formats:
+      default: "%Y年%m月%d日 %H:%M"
+      short: "%m/%d %H:%M"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒"
+
   # ボタンやリンクテキスト
   helpers:
     submit:
@@ -122,4 +112,3 @@ ja:
         update: "日報を更新"
       user:
         create: "アカウント作成"
-        update: "アカウント更新" 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,125 @@
+ja:
+  activerecord:
+    models:
+      user: "ユーザー"
+      report: "日報"
+    
+    attributes:
+      user:
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "パスワード確認"
+        current_password: "現在のパスワード"
+        remember_me: "ログイン状態を保持する"
+      
+      report:
+        date: "日付"
+        body: "内容"
+        user: "ユーザー"
+        created_at: "作成日時"
+        updated_at: "更新日時"
+    
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              blank: "を入力してください"
+              invalid: "の形式が正しくありません"
+              taken: "は既に使用されています"
+            password:
+              blank: "を入力してください"
+              too_short: "は%{count}文字以上で入力してください"
+              confirmation: "と確認が一致しません"
+        
+        report:
+          attributes:
+            date:
+              blank: "を入力してください"
+              taken: "の日報は既に作成されています"
+            body:
+              blank: "を入力してください"
+  
+  # フラッシュメッセージ
+  flash:
+    reports:
+      create:
+        notice: "日報を作成しました"
+        alert: "日報の作成に失敗しました"
+      update:
+        notice: "日報を更新しました"
+        alert: "日報の更新に失敗しました"
+      destroy:
+        notice: "日報を削除しました"
+        alert: "日報の削除に失敗しました"
+  
+  # 日付・時間の表示フォーマット
+  date:
+    formats:
+      default: "%Y年%m月%d日"
+      short: "%m/%d"
+      long: "%Y年%m月%d日(%a)"
+  
+  time:
+    formats:
+      default: "%Y年%m月%d日 %H:%M"
+      short: "%m/%d %H:%M"
+      long: "%Y年%m月%d日(%a) %H時%M分%S秒"
+  
+  # 曜日
+  date:
+    abbr_day_names:
+      - 日
+      - 月
+      - 火
+      - 水
+      - 木
+      - 金
+      - 土
+    day_names:
+      - 日曜日
+      - 月曜日
+      - 火曜日
+      - 水曜日
+      - 木曜日
+      - 金曜日
+      - 土曜日
+    
+    abbr_month_names:
+      - ~
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+    month_names:
+      - ~
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
+  
+  # ボタンやリンクテキスト
+  helpers:
+    submit:
+      report:
+        create: "日報を作成"
+        update: "日報を更新"
+      user:
+        create: "アカウント作成"
+        update: "アカウント更新" 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,8 @@ Rails.application.routes.draw do
   # Calendar route
   get "calendar" => "calendar#index"
 
+  # Reports routes
+  resources :reports, only: [:new, :create]
+
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/db/migrate/20250606230101_create_reports.rb
+++ b/db/migrate/20250606230101_create_reports.rb
@@ -1,0 +1,13 @@
+class CreateReports < ActiveRecord::Migration[7.1]
+  def change
+    create_table :reports do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :date, null: false
+      t.text :body, null: false
+
+      t.timestamps
+    end
+    
+    add_index :reports, [:user_id, :date], unique: true
+  end
+end 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_06_225842) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_06_230101) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "reports", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "date", null: false
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "date"], name: "index_reports_on_user_id_and_date", unique: true
+    t.index ["user_id"], name: "index_reports_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -26,4 +36,5 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_06_225842) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "reports", "users"
 end


### PR DESCRIPTION
## 概要

日報作成機能実装

## 関連するissue番号

- #9 

## 行ったこと

- reportsテーブル作成
- 日報作成機能実装
- カレンダーで日報を作成した日付をマークする

## 動作確認

日報作成ページ http://localhost:3000/reports/new

## その他

現時点ではカレンダーの日付から日報詳細ページに遷移されるようになっているが、日報があれば編集フォームに、なければ登録フォームに遷移するようにして、詳細ページはなしで、フォームにプレビュー機能を追加する予定


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced daily report creation functionality, allowing users to create and submit reports for specific dates.
  - Calendar view now displays clickable days linking to report creation pages pre-filled with the respective date.
  - Visual indicators on the calendar show which days have reports (green dot) and highlight the current day (blue dot).
  - Added a fixed-position button for quick report creation for today.
  - Japanese language support added for UI, validation messages, and date formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->