### PR TITLE
日報削除機能実装

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,6 +1,6 @@
 class ReportsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_report, only: [:edit, :update]
+  before_action :set_report, only: [:edit, :update, :destroy]
 
   def new
     @report = current_user.reports.build
@@ -34,6 +34,11 @@ class ReportsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @report.destroy!
+    redirect_to calendar_path, notice: t("flash.reports.destroy.notice")
   end
 
   private

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -31,8 +31,20 @@
 
   <!-- 送信ボタン -->
   <div class="flex items-center justify-between pt-6">
-    <%= link_to "キャンセル", calendar_path, 
-        class: "text-gray-600 hover:text-gray-900 px-4 py-2 border border-gray-300 rounded-md transition-colors" %>
+    <div class="flex items-center space-x-3">
+      <%= link_to "キャンセル", calendar_path, 
+          class: "text-gray-600 hover:text-gray-900 px-4 py-2 border border-gray-300 rounded-md transition-colors" %>
+      
+      <% if @report.persisted? %>
+        <%= link_to "削除", report_path(@report), 
+            method: :delete,
+            data: { 
+              confirm: "#{@report.date.strftime('%Y年%m月%d日')}の日報を削除してもよろしいですか？",
+              turbo_method: :delete
+            },
+            class: "text-red-600 hover:text-red-700 px-4 py-2 border border-red-300 hover:border-red-400 rounded-md transition-colors" %>
+      <% end %>
+    </div>
     
     <%= form.submit @report.persisted? ? t('helpers.submit.report.update') : t('helpers.submit.report.create'), 
         class: "bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-md shadow transition-colors" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   get "calendar" => "calendar#index"
 
   # Reports routes
-  resources :reports, only: [:new, :create, :edit, :update]
+  resources :reports, only: [:new, :create, :edit, :update, :destroy]
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end


### PR DESCRIPTION
## 概要

日報削除機能実装

## 関連するissue番号

- #28 

## 行ったこと

- 編集フォームに削除ボタン作成
- 日報削除処理実装

## 動作確認

http://localhost:3000

1. 日報編集画面にアクセス
2. 削除ボタンをクリック
3. 削除処理実行
4. 削除後はカレンダー画面にリダイレクト
5. フラッシュメッセージを表示

## その他
