### PR TITLE
feat: テンプレート作成機能の実装

### DIFF
--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -1,0 +1,23 @@
+class TemplatesController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @template = current_user.templates.build
+  end
+
+  def create
+    @template = current_user.templates.build(template_params)
+
+    if @template.save
+      redirect_to calendar_path, notice: t("flash.templates.create.notice")
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+    def template_params
+      params.require(:template).permit(:title, :body)
+    end
+end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -1,0 +1,6 @@
+class Template < ApplicationRecord
+  belongs_to :user
+
+  validates :title, presence: true, length: { maximum: 100 }
+  validates :body, presence: true, length: { maximum: 500 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :reports, dependent: :destroy
+  has_many :templates, dependent: :destroy
 
   # カスタムパスワードバリデーション
   validate :password_complexity, if: :password_required?

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -16,6 +16,12 @@
           </svg>
           <span>カレンダー</span>
         <% end %>
+        <%= link_to templates_path, class: "text-gray-700 hover:text-gray-900 px-4 py-2 rounded transition-colors flex items-center space-x-1" do %>
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+          </svg>
+          <span>テンプレート</span>
+        <% end %>
         <span class="text-gray-700">
           <%= current_user.email %>
         </span>

--- a/app/views/templates/new.html.erb
+++ b/app/views/templates/new.html.erb
@@ -55,7 +55,7 @@
             class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors",
             rows: 16,
             placeholder: "例:\n\n## 今日の学習内容\n\n### 進捗\n- \n\n### 学んだこと\n- \n\n### 明日の予定\n- \n\n### 課題・疑問\n- ",
-            maxlength: 10000 %>
+            maxlength: 500 %>
         <p class="mt-1 text-sm text-gray-500">Markdown記法で記述できます（最大500文字）</p>
       </div>
 

--- a/app/views/templates/new.html.erb
+++ b/app/views/templates/new.html.erb
@@ -1,0 +1,84 @@
+<div class="max-w-4xl mx-auto px-4 py-8">
+  <!-- ヘッダー部分 -->
+  <div class="mb-8">
+    <div class="flex items-center space-x-4 mb-6">
+      <%= link_to templates_path, class: "text-gray-600 hover:text-gray-800 flex items-center space-x-1 transition-colors" do %>
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
+        </svg>
+        <span>テンプレート一覧に戻る</span>
+      <% end %>
+    </div>
+    
+    <h1 class="text-3xl font-bold text-gray-900">新しいテンプレートを作成</h1>
+    <p class="text-gray-600 mt-2">日報作成を効率化するテンプレートを作成しましょう</p>
+  </div>
+
+  <!-- フォーム部分 -->
+  <div class="bg-white rounded-lg border border-gray-200 shadow-sm">
+    <%= form_with model: @template, local: true, class: "p-8" do |form| %>
+      <!-- エラーメッセージ -->
+      <% if @template.errors.any? %>
+        <div class="mb-6 bg-red-50 border border-red-200 rounded-lg p-4">
+          <div class="flex">
+            <svg class="w-5 h-5 text-red-400 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+            </svg>
+            <div class="ml-3">
+              <h3 class="text-sm font-medium text-red-800">入力エラーがあります</h3>
+              <div class="mt-2 text-sm text-red-700">
+                <ul class="list-disc list-inside space-y-1">
+                  <% @template.errors.full_messages.each do |message| %>
+                    <li><%= message %></li>
+                  <% end %>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+
+      <!-- タイトル入力 -->
+      <div class="mb-6">
+        <%= form.label :title, "テンプレート名", class: "block text-sm font-medium text-gray-700 mb-2" %>
+        <%= form.text_field :title, 
+            class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors",
+            placeholder: "例: 学習記録テンプレート、開発タスクテンプレート",
+            maxlength: 100 %>
+        <p class="mt-1 text-sm text-gray-500">テンプレートを識別しやすい名前をつけてください（最大100文字）</p>
+      </div>
+
+      <!-- 本文入力 -->
+      <div class="mb-8">
+        <%= form.label :body, "テンプレート内容", class: "block text-sm font-medium text-gray-700 mb-2" %>
+        <%= form.text_area :body, 
+            class: "w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors",
+            rows: 16,
+            placeholder: "例:\n\n## 今日の学習内容\n\n### 進捗\n- \n\n### 学んだこと\n- \n\n### 明日の予定\n- \n\n### 課題・疑問\n- ",
+            maxlength: 10000 %>
+        <p class="mt-1 text-sm text-gray-500">Markdown記法で記述できます（最大500文字）</p>
+      </div>
+
+      <!-- ボタン群 -->
+      <div class="flex justify-between items-center">
+        <%= link_to templates_path, class: "px-6 py-3 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 font-medium transition-colors" do %>
+          キャンセル
+        <% end %>
+        
+        <%= form.submit "テンプレートを作成", 
+            class: "px-8 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors" %>
+      </div>
+    <% end %>
+  </div>
+
+  <!-- ヘルプセクション -->
+  <div class="mt-8 bg-blue-50 rounded-lg border border-blue-200 p-6">
+    <h3 class="text-sm font-medium text-blue-800 mb-3">💡 テンプレート作成のコツ</h3>
+    <ul class="text-sm text-blue-700 space-y-2">
+      <li>• <strong>見出し</strong>: ## や ### を使って構造を明確にする</li>
+      <li>• <strong>リスト</strong>: - や * を使って項目を整理する</li>
+      <li>• <strong>プレースホルダー</strong>: 入力箇所を明確にしておく</li>
+      <li>• <strong>カテゴリ分け</strong>: 学習内容、課題、次の目標など分類する</li>
+    </ul>
+  </div>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       user: "ユーザー"
       report: "日報"
+      template: "テンプレート"
     attributes:
       user:
         email: "メールアドレス"
@@ -13,6 +14,12 @@ ja:
       report:
         date: "日付"
         body: "内容"
+        user: "ユーザー"
+        created_at: "作成日時"
+        updated_at: "更新日時"
+      template:
+        title: "テンプレート名"
+        body: "テンプレート内容"
         user: "ユーザー"
         created_at: "作成日時"
         updated_at: "更新日時"
@@ -35,6 +42,14 @@ ja:
               taken: "の日報は既に作成されています"
             body:
               blank: "を入力してください"
+        template:
+          attributes:
+            title:
+              blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
+            body:
+              blank: "を入力してください"
+              too_long: "は%{count}文字以内で入力してください"
   # フラッシュメッセージ
   flash:
     reports:
@@ -47,6 +62,16 @@ ja:
       destroy:
         notice: "日報を削除しました"
         alert: "日報の削除に失敗しました"
+    templates:
+      create:
+        notice: "テンプレートを作成しました"
+        alert: "テンプレートの作成に失敗しました"
+      update:
+        notice: "テンプレートを更新しました"
+        alert: "テンプレートの更新に失敗しました"
+      destroy:
+        notice: "テンプレートを削除しました"
+        alert: "テンプレートの削除に失敗しました"
   # 日付・時間の表示フォーマット
   date:
     formats:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,83 +1,83 @@
 ja:
   activerecord:
     models:
-      user: "ユーザー"
-      report: "日報"
-      template: "テンプレート"
+      user: 'ユーザー'
+      report: '日報'
+      template: 'テンプレート'
     attributes:
       user:
-        email: "メールアドレス"
-        password: "パスワード"
-        password_confirmation: "パスワード確認"
-        current_password: "現在のパスワード"
-        remember_me: "ログイン状態を保持する"
+        email: 'メールアドレス'
+        password: 'パスワード'
+        password_confirmation: 'パスワード確認'
+        current_password: '現在のパスワード'
+        remember_me: 'ログイン状態を保持する'
       report:
-        date: "日付"
-        body: "内容"
-        user: "ユーザー"
-        created_at: "作成日時"
-        updated_at: "更新日時"
+        date: '日付'
+        body: '内容'
+        user: 'ユーザー'
+        created_at: '作成日時'
+        updated_at: '更新日時'
       template:
-        title: "テンプレート名"
-        body: "テンプレート内容"
-        user: "ユーザー"
-        created_at: "作成日時"
-        updated_at: "更新日時"
+        title: 'テンプレート名'
+        body: 'テンプレート内容'
+        user: 'ユーザー'
+        created_at: '作成日時'
+        updated_at: '更新日時'
     errors:
       models:
         user:
           attributes:
             email:
-              blank: "を入力してください"
-              invalid: "の形式が正しくありません"
-              taken: "は既に使用されています"
+              blank: 'を入力してください'
+              invalid: 'の形式が正しくありません'
+              taken: 'は既に使用されています'
             password:
-              blank: "を入力してください"
-              too_short: "は%{count}文字以上で入力してください"
-              confirmation: "と確認が一致しません"
+              blank: 'を入力してください'
+              too_short: 'は%{count}文字以上で入力してください'
+              confirmation: 'と確認が一致しません'
         report:
           attributes:
             date:
-              blank: "を入力してください"
-              taken: "の日報は既に作成されています"
+              blank: 'を入力してください'
+              taken: 'の日報は既に作成されています'
             body:
-              blank: "を入力してください"
+              blank: 'を入力してください'
         template:
           attributes:
             title:
-              blank: "を入力してください"
-              too_long: "は%{count}文字以内で入力してください"
+              blank: 'を入力してください'
+              too_long: 'は%{count}文字以内で入力してください'
             body:
-              blank: "を入力してください"
-              too_long: "は%{count}文字以内で入力してください"
+              blank: 'を入力してください'
+              too_long: 'は%{count}文字以内で入力してください'
   # フラッシュメッセージ
   flash:
     reports:
       create:
-        notice: "日報を作成しました"
-        alert: "日報の作成に失敗しました"
+        notice: '日報を作成しました'
+        alert: '日報の作成に失敗しました'
       update:
-        notice: "日報を更新しました"
-        alert: "日報の更新に失敗しました"
+        notice: '日報を更新しました'
+        alert: '日報の更新に失敗しました'
       destroy:
-        notice: "日報を削除しました"
-        alert: "日報の削除に失敗しました"
+        notice: '日報を削除しました'
+        alert: '日報の削除に失敗しました'
     templates:
       create:
-        notice: "テンプレートを作成しました"
-        alert: "テンプレートの作成に失敗しました"
+        notice: 'テンプレートを作成しました'
+        alert: 'テンプレートの作成に失敗しました'
       update:
-        notice: "テンプレートを更新しました"
-        alert: "テンプレートの更新に失敗しました"
+        notice: 'テンプレートを更新しました'
+        alert: 'テンプレートの更新に失敗しました'
       destroy:
-        notice: "テンプレートを削除しました"
-        alert: "テンプレートの削除に失敗しました"
+        notice: 'テンプレートを削除しました'
+        alert: 'テンプレートの削除に失敗しました'
   # 日付・時間の表示フォーマット
   date:
     formats:
-      default: "%Y年%m月%d日"
-      short: "%m/%d"
-      long: "%Y年%m月%d日(%a)"
+      default: '%Y年%m月%d日'
+      short: '%m/%d'
+      long: '%Y年%m月%d日(%a)'
     abbr_day_names:
       - 日
       - 月
@@ -125,15 +125,15 @@ ja:
 
   time:
     formats:
-      default: "%Y年%m月%d日 %H:%M"
-      short: "%m/%d %H:%M"
-      long: "%Y年%m月%d日(%a) %H時%M分%S秒"
+      default: '%Y年%m月%d日 %H:%M'
+      short: '%m/%d %H:%M'
+      long: '%Y年%m月%d日(%a) %H時%M分%S秒'
 
   # ボタンやリンクテキスト
   helpers:
     submit:
       report:
-        create: "日報を作成"
-        update: "日報を更新"
+        create: '日報を作成'
+        update: '日報を更新'
       user:
-        create: "アカウント作成"
+        create: 'アカウント作成'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,5 +15,7 @@ Rails.application.routes.draw do
   # Reports routes
   resources :reports, only: [:new, :create, :edit, :update, :destroy]
 
+  resources :templates, only: [:new, :create]
+
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/db/migrate/20250608124052_create_templates.rb
+++ b/db/migrate/20250608124052_create_templates.rb
@@ -1,0 +1,11 @@
+class CreateTemplates < ActiveRecord::Migration[7.1]
+  def change
+    create_table :templates do |t|
+      t.string :title, null: false
+      t.text :body, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_06_230101) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_08_124052) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,15 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_06_230101) do
     t.datetime "updated_at", null: false
     t.index ["user_id", "date"], name: "index_reports_on_user_id_and_date", unique: true
     t.index ["user_id"], name: "index_reports_on_user_id"
+  end
+
+  create_table "templates", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "body", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_templates_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -37,4 +46,5 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_06_230101) do
   end
 
   add_foreign_key "reports", "users"
+  add_foreign_key "templates", "users"
 end


### PR DESCRIPTION
## 📋 概要
テンプレート作成機能を実装しました。ユーザーが日報作成を効率化するためのテンプレートを作成・管理できるようになります。

## 🎯 実装内容

### 新機能
- **Templateモデル**: title, body, user_idフィールド
- **テンプレート作成画面**: モダンでユーザーフレンドリーなUI
- **ヘッダーナビゲーション**: テンプレート管理へのアクセス

### バリデーション
- タイトル: 必須、最大100文字
- 本文: 必須、最大500文字

### 国際化対応
- 日本語エラーメッセージ
- フラッシュメッセージの翻訳

### UI/UX
- TailwindCSSを使用したモダンなデザイン
- レスポンシブ対応
- エラーハンドリング
- ヘルプセクション付き

## 🔄 動作フロー
1. ヘッダーの「テンプレート」ボタンクリック
2. テンプレート作成画面で内容入力
3. バリデーション通過後、テンプレート保存
4. カレンダー画面にリダイレクト

## ✅ 関連Issue
Resolves #33

## 📸 スクリーンショット
（テンプレート作成画面のスクリーンショットを後で追加）

## 🧪 テスト
- [ ] テンプレート作成の正常系テスト
- [ ] バリデーションエラーテスト
- [ ] 認証が必要なことのテスト

## 📝 補足
- テンプレート一覧機能は次のPRで実装予定
- 日報作成時のテンプレート選択機能も後続で実装予定

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "Templates" section accessible from the main navigation for signed-in users.
  - Added the ability to create new templates with title and body fields, including validation and Markdown support.
  - Provided a dedicated form page for creating templates, with user guidance and error handling.
  - Japanese localization support for templates, including field names, error messages, and flash notifications.
- **Database**
  - Added a new "templates" table linked to users, with appropriate constraints and indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->